### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-assessment.yml
+++ b/.github/workflows/security-assessment.yml
@@ -1,4 +1,6 @@
 name: Security Assessment & Documentation
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/4](https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow. The best way is to set it at the top level of the workflow file, so it applies to all jobs unless overridden. Since the jobs only need to check out code and upload artifacts, the minimal required permission is `contents: read`. This should be added after the `name` and before the `on` block (e.g., after line 1). No other changes are needed, and this will not affect existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
