### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,6 @@
 name: 🛡 Semgrep Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/5](https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (to check out code and scan it), set `contents: read`. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the workflow level, just after the `name` field and before the `on` block, to ensure all jobs inherit these minimal permissions unless overridden. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
