### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,4 +1,6 @@
 name: 📜 License Checker
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/9](https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/9)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. In this case, since the job only checks licenses and does not need to write to the repository or interact with issues or pull requests, the minimal permission required is `contents: read`. The best way to implement this is to add the following block at the top level of the workflow (after the `name` field and before `on:`), which will apply to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
