### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,4 +1,6 @@
 name: 🧹 ESLint + Security Rules
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/8](https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/8)

To fix the problem, we should add a `permissions` block to the workflow or the specific job. Since the job only checks out code, installs dependencies, and runs ESLint, it only needs read access to the repository contents. The best way to fix this is to add `permissions: contents: read` at the workflow level (top-level, after the `name` and before `on`), which will apply to all jobs unless overridden. This change should be made in the `.github/workflows/eslint.yml` file, at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
