### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,4 +1,6 @@
 name: 🏗 Checkov IaC Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/7](https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the workflow only checks out code and runs a scan, it only needs read access to repository contents. The best way to fix this is to add `permissions: { contents: read }` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden. This change is minimal, does not affect existing functionality, and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
