### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,6 +2,9 @@ name: 🔐 Gitleaks Secret Scan
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/6](https://github.com/CarineJackson1/CarineJackson1/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` permissions to only what is necessary. For a Gitleaks scan, the minimal required permission is `contents: read`, which allows the workflow to read the repository contents but not modify them. This block should be added at the top level of the workflow file (before `jobs:`) so that it applies to all jobs in the workflow. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
